### PR TITLE
Remove version from ICD10 CodeSystem.valueSet URI

### DIFF
--- a/src/main/java/au/csiro/fhir/transforms/parsers/ICDParser.java
+++ b/src/main/java/au/csiro/fhir/transforms/parsers/ICDParser.java
@@ -236,7 +236,7 @@ public class ICDParser {
 		dt.setValueAsString(version.equals("5.0")?"2016-04-01":(version.equals("4.0")?"2012-04-01":null));
 
 		codeSystem.setUrl("http://hl7.org/fhir/sid/icd-10-uk")
-				.setValueSet("http://hl7.org/fhir/sid/icd-10-uk/vs" + "|" + version)
+				.setValueSet("http://hl7.org/fhir/sid/icd-10-uk/vs")
 				.setDateElement(dt)
 				.setName("ICD_10_UK")
 				.setVersion(version)


### PR DESCRIPTION
The ICD 10 transform is the only transform in this set that creates a "canonical" style URI for CodeSystem.valueSet, with the version appended to the base URI after a pipe character.

This is syntactically legal (the field is a canonical in FHIR) but doesn't really make sense for an implicit ValueSet, as the version after the pipe refers to the version of the ValueSet. While explicit ValueSets have versions, implicit ones don't and therefore the canonical URI refers to a version of an implicit ValueSet which by definition doesn't exist.

For consistency with the rest of the transformed content, and for the above mentioned issue, the CodeSystem.valueSet has been set to http://hl7.org/fhir/sid/icd-10-uk/vs without any additional version information. When expanded this will default to the latest version of ICD 10 UK that th server has, and a user can specify a version by adding the parameter `system-version` to the expansion request.