### PR TITLE
Feed exit on failure

### DIFF
--- a/src/main/java/au/csiro/fhir/transforms/Parser.java
+++ b/src/main/java/au/csiro/fhir/transforms/Parser.java
@@ -3,8 +3,8 @@
  * ABN 41 687 119 230. Licensed under the CSIRO Open Source Software Licence Agreement.
  */
 
-package au.csiro.fhir.transforms;
-
+		package au.csiro.fhir.transforms;
+		
 import java.io.IOException;
 import java.io.StringReader;
 import java.lang.reflect.InvocationTargetException;
@@ -33,13 +33,13 @@ import au.csiro.fhir.transforms.parsers.OPCSParser;
 
 public class Parser {
 
-	// private final String properties_file_name = "config.properties";
-
+		// private final String properties_file_name = "config.properties";
+		
 	Properties props = new Properties();
 	String outFolder = null;
 	String txServer = null;
 	FeedClient feedClient= null;
-	
+
 	String feedServer = null;
 	String feedClientId = null;
 	String feedClientSecret = null;
@@ -59,7 +59,7 @@ public class Parser {
 		txServer = props.getProperty("tx.server.url");
 		if (txServer != null) {
 			System.out.printf("FHIR terminology server URL is %s \n", txServer);
-		}	
+		}
 		feedServer = props.getProperty("feed.server.name");
 		feedClientId = props.getProperty("feed.server.client.id");
 		feedClientSecret= props.getProperty("feed.server.client.secret");
@@ -73,7 +73,7 @@ public class Parser {
 	}
 
 	private void parseCTV2() throws IOException, ParseException {
-		String termFile = props.getProperty("ctv2.termFile");	
+		String termFile = props.getProperty("ctv2.termFile");
 		CTV2Parser parser = new CTV2Parser();
 		String domain = "";
 		if(termFile.contains("UNIFIED")) {
@@ -84,7 +84,7 @@ public class Parser {
 		}
 		parser.processCodeSystemWithUpdate( termFile, "20160401", outFolder, txServer, feedClient,  domain);
 	}
-	
+
 	private void parseCTV3() throws IOException, ParseException {
 		CTV3Parser parser = new CTV3Parser();
 		Set<String> versions = new HashSet<String>();
@@ -97,7 +97,7 @@ public class Parser {
 			String folder = props.getProperty("ctv3.version." + v + ".folder");
 			parserSingleVersionCTV3(folder,historyFile, v, parser);
 		}
-	
+
 	}
 
 	private void parseNICIP() throws IOException {
@@ -109,8 +109,8 @@ public class Parser {
 	}
 
 	private void parseICD() throws IOException, ParseException {
-		ICDParser parser = new ICDParser();
 		for (String s : getPropertiesWithStartString("icd10uk.version")) {
+			ICDParser parser = new ICDParser();
 			String version = s.split("\\.")[2];
 			version = version.replaceAll("/", ".");
 			String codeFile = props.getProperty(s);
@@ -168,13 +168,13 @@ public class Parser {
 			parser.processResourceWithUpdate(packageFolder, version, outFolder, txServer,feedClient);
 		}
 	}
-	
+
 	private void parseDMD() throws IOException, ParseException, JAXBException, NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-		String dmdFolder = props.getProperty("dmd.releaseFolder");	
-		String dmdSerial = props.getProperty("dmd.releaseSerial");	
-		String supportFile =  "dm+d Content For Terminology Server.xlsx";	
+		String dmdFolder = props.getProperty("dmd.releaseFolder");
+		String dmdSerial = props.getProperty("dmd.releaseSerial");
+		String supportFile =  "dm+d Content For Terminology Server.xlsx";
 		String gtinFile =  props.getProperty("dmd.gtinFile");
-;		DMDParser parser = new DMDParser();
+		;		DMDParser parser = new DMDParser();
 		parser.processSupportCodeSystemWithUpdate(dmdFolder, dmdSerial, outFolder, txServer, feedClient);
 		parser.processCodeSystemWithUpdate( dmdFolder,dmdSerial ,supportFile,outFolder, txServer, feedClient);
 		// parser.processGtinMappingmWithUpdate(dmdFolder,gtinFile,outFolder, txServer, feedClient);

--- a/src/main/java/au/csiro/fhir/transforms/helper/FeedClient.java
+++ b/src/main/java/au/csiro/fhir/transforms/helper/FeedClient.java
@@ -28,43 +28,49 @@ import com.google.gson.JsonObject;
 import au.csiro.fhir.transforms.helper.atomio.Entry;
 
 public class FeedClient {
-	
+
 	final Logger logger = Logger.getLogger(FeedClient.class.getName());
 
-	
+
 	String syndCientID;
 	String syndSecret;
 	String realm;
 	String authServer;
-	
-	
+
+
 	String feed;
-	
+
 	Client client = null;
 
 	public FeedClient(String feedName) {
 		feed = feedName;
 		Feature feature = new LoggingFeature(logger, Level.INFO, null, null);
 		client = ClientBuilder.newBuilder().register(feature).build();
-		
+
 	}
-	
+
 	public FeedClient(String feedName, String cid, String pwd, String realm, String auth) {
 		syndCientID = cid;
 		syndSecret = pwd;
 		this.realm = realm;
 		authServer = auth;
-		
+
 		feed = feedName;
 		Feature feature = new LoggingFeature(logger, Level.INFO, null, null);
 		client = ClientBuilder.newBuilder().register(feature).build();
-		
+
+	}
+
+	public void checkResponse(Response response) {
+		if (response.getStatusInfo().getFamily().equals(Response.Status.Family.SUCCESSFUL) == false) {
+			throw new RuntimeException("Failed : HTTP error code : " + response.getStatus() + " : " + response.toString());
+		}
 	}
 
 	public void deleteEntryFromFeed(String id) {
-		
+
 		System.out.println("delete "  + id);
-		
+
 		WebTarget webTarget = client.target(feed);
 
 		WebTarget deleteEntryTarget = webTarget.path("entry/" + id);
@@ -73,11 +79,13 @@ public class FeedClient {
 
 		Response response = invocationBuilder.header(HttpHeaders.AUTHORIZATION, "Bearer " + getToken()).delete();
 
+		checkResponse(response);
+
 		logger.info(response.toString());
 	}
-	
+
 	public String searchEntryByIdentifierAndVersion( String contentItemIdentifier, String contentItemVersion) {
-		
+
 		WebTarget webTarget = client.target(feed);
 
 		WebTarget findEntryTarget = webTarget.path("");
@@ -85,7 +93,7 @@ public class FeedClient {
 		Invocation.Builder invocationBuilder = findEntryTarget.request();
 
 		Response response = invocationBuilder.header(HttpHeaders.AUTHORIZATION, "Bearer " + getToken()).get();
-		
+
 		JsonObject jobj = new Gson().fromJson(response.readEntity(String.class), JsonObject.class);
 
 		for(JsonElement e  : (JsonArray) jobj.get("entries")) {
@@ -96,57 +104,58 @@ public class FeedClient {
 				System.out.println("FOUND" + id +"\t" + identifier + "\t" + version);
 				return id;
 			}
-			
+
 		}
-		
+
 		return null;
 	}
 	
 	
 
 	public void createEntryToNHSFeed(File entryFile, File bodyFile) throws IOException {
-	
+
 		WebTarget webTarget = client.target(feed);
 
 		WebTarget createEntryTarget = webTarget.path("entry/");
-		
+
 		createEntryTarget.register(MultiPartFeature.class);
-		
+
 		final FileDataBodyPart entryFilePart = new FileDataBodyPart("entry", entryFile, MediaType.APPLICATION_JSON_TYPE);
 		final FileDataBodyPart bodyFilePart = new FileDataBodyPart("file", bodyFile);
-			   
+
 		FormDataMultiPart formDataMultiPart = new FormDataMultiPart();
-	    final FormDataMultiPart multiPartEntity = (FormDataMultiPart) formDataMultiPart.bodyPart(bodyFilePart).bodyPart(entryFilePart);	
+		final FormDataMultiPart multiPartEntity = (FormDataMultiPart) formDataMultiPart.bodyPart(bodyFilePart).bodyPart(entryFilePart);
 		Response response = createEntryTarget.request()
 				.header(HttpHeaders.AUTHORIZATION, "Bearer " + getToken())
 				//.header(HttpHeaders.CONTENT_TYPE, "multipart/form-data")
 				.post(Entity.entity(multiPartEntity, multiPartEntity.getMediaType()));
 
+		checkResponse(response);
 		logger.info(response.toString());
 		formDataMultiPart.close();
 	}
-	
+
 	/**
-	 * 
+	 *
 	 * Delete exiting one and recreate
 	 */
 	public void updateEntryToNHSFeed(Entry entry ,File entryFile, File bodyFile) throws IOException {
-		
+
 		String id = searchEntryByIdentifierAndVersion(entry.getContentItemIdentifier(), entry.getContentItemVersion());
 		if(id!=null) {
 			deleteEntryFromFeed(id);
 		}
 		createEntryToNHSFeed(entryFile, bodyFile);
 	}
-	
+
 	public void deleteEntryFromNHSFeed(Entry entry ,File entryFile, File bodyFile) throws IOException {
-		
+
 		String id = searchEntryByIdentifierAndVersion(entry.getContentItemIdentifier(), entry.getContentItemVersion());
 		if(id!=null) {
 			deleteEntryFromFeed(id);
 		}
 	}
-	
+
 	private String getToken() {
 		String token = "";
 		Logger logger = Logger.getLogger(FeedClient.class.getName());
@@ -162,8 +171,8 @@ public class FeedClient {
 		Entity<Form> entity = Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED);
 		Invocation.Builder invocationBuilder = getTokenTarget.request(MediaType.APPLICATION_JSON);
 		Response response = invocationBuilder.post(entity);
-		if (response.getStatus() != 200)
-			throw new RuntimeException("Failed : HTTP error code : " + response.getStatus());
+		checkResponse(response);
+
 		JsonObject jobj = new Gson().fromJson(response.readEntity(String.class), JsonObject.class);
 		token = jobj.get("access_token").toString().replaceAll("\"", "");
 		return token;


### PR DESCRIPTION
Make feed operations exit on fail rather than just log failure.

Also included is a defect fix for processing multiple ICD versions - ICDParser has cached state which needs to be reset between executions.